### PR TITLE
Handle 412 "No Change" change errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simperium Client library for Node.js
 
-[![Build Status](https://travis-ci.org/beaucollins/node-simperium.png)](https://travis-ci.org/beaucollins/node-simperium)
+[![Build Status](https://travis-ci.org/beaucollins/node-simperium.png)](https://travis-ci.org/automattic/node-simperium)
 
 
 Goal: To have a feature complete Simperium client using the websocket API and adaptable local storage layers.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simperium Client library for Node.js
 
-[![Build Status](https://travis-ci.org/beaucollins/node-simperium.png)](https://travis-ci.org/automattic/node-simperium)
+[![Build Status](https://travis-ci.org/Automattic/node-simperium.png)](https://travis-ci.org/Automattic/node-simperium)
 
 
 Goal: To have a feature complete Simperium client using the websocket API and adaptable local storage layers.

--- a/lib/simperium/channel.js
+++ b/lib/simperium/channel.js
@@ -38,6 +38,7 @@ function Channel(appid, access_token, bucket, store){
   this.localQueue = new LocalQueue(this.store);
 
   this.localQueue.on('send', private.sendChange.bind(this));
+  this.localQueue.on('error', private.handleChangeError.bind(this));
 
   this.on('index', function(cv){
     private.updateChangeVersion.call(channel, cv).then(function() {
@@ -376,7 +377,19 @@ private.changeObject = function(id, change){
 };
 
 private.buildModifyChange = function(id, object, ghost){
-  var payload = change_util.buildChange(change_util.type.MODIFY, id, object, ghost);
+  var payload = change_util.buildChange(change_util.type.MODIFY, id, object, ghost),
+      empty = true;
+
+  for( var key in payload.v ) {
+    if (key) {
+      empty = false;
+      break;
+    }
+  }
+
+  if (empty) return this.emit('unmodified', id, object, ghost);
+
+  // if the change v is an empty object, do not send, notify?
   this.localQueue.queue(payload);
 };
 
@@ -471,7 +484,7 @@ private.applyChange = function(change, ghost){
     error.code = change.error;
     error.change = change;
     error.ghost = ghost;
-    this.emit('error', error, change);
+    private.handleChangeError.call(this, error, change, acknowledged);
     return;
   }
 
@@ -490,6 +503,18 @@ private.applyChange = function(change, ghost){
 
   } else if (change.o == operation.REMOVE) {
     return private.removeObject.bind(this)(change.id, acknowledged).then(emit);
+  }
+
+};
+
+private.handleChangeError = function(err, change, acknowledged) {
+
+  switch(err.code) {
+  case 412: // Change causes no change, just acknowledge it
+    private.updateAcknowledged.call(this, acknowledged);
+    break;
+  default:
+    this.emit('error', err, change);
   }
 
 };

--- a/lib/simperium/ghost/store.js
+++ b/lib/simperium/ghost/store.js
@@ -47,10 +47,11 @@ Store.prototype.get = function(id){
       ghost = this.index[id];
 
   if (!ghost){
-    ghost = {data:{}};
+    ghost = {data:{}, id: id};
     this.index[id] = JSON.stringify(ghost);
   } else {
     ghost = JSON.parse(ghost);
+    ghost.id = id;
   }
 
   process.nextTick(function(){


### PR DESCRIPTION
Implements two things:

1) Doesn't send a change if the diff is empty
2) When a 412 is received, marks the change as acknowledged and continues

Fixes #1