### PR TITLE
Fixes TypeError when using with webpack

### DIFF
--- a/lib/simperium/client.js
+++ b/lib/simperium/client.js
@@ -10,7 +10,7 @@ var defaultGhostStoreProvider = require('./ghost/default');
 var defaultObjectStoreProvider = require('./storage/default');
 
 var WebSocketClient;
-if (this.window && this.window.WebSocket) {
+if (typeof window !== 'undefined' && window.WebSocket) {
   WebSocketClient = window.WebSocket;
 } else {
   WebSocketClient = require('websocket').w3cwebsocket;


### PR DESCRIPTION
Might be webpack-specific, but `require`-ing simperium on the server results in an error:

```
node_modules/simperium/lib/simperium/client.js:15
if (undefined.window && undefined.window.WebSocket) {
             ^
TypeError: Cannot read property 'window' of undefined
    at Object.<anonymous> (node_modules/simperium/lib/simperium/client.js:13:5)
    at Module._compile (module.js:456:26)
    at normalLoader (node_modules/babel-core/lib/api/register/node.js:199:5)
    at Object.require.extensions.(anonymous function) [as .js] (node_modules/babel-core/lib/api/register/node.js:216:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (node_modules/simperium/lib/simperium/index.js:2:14)
    at Module._compile (module.js:456:26)
```

node v0.10.35
npm  v2.1.18